### PR TITLE
Add Starship prompt configuration

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -7,9 +7,12 @@ alias ll="ls -lFh"
 alias la="ls -Al"
 
 # Paths
-export PATH="$HOME/bin:$PATH"
+export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 
 # keybase
 # https://github.com/keybase/keybase-issues/issues/2798
 export GPG_TTY=$(tty)
+
+# Starship prompt
+eval "$(starship init bash)"
 

--- a/starship/.config/starship.toml
+++ b/starship/.config/starship.toml
@@ -1,0 +1,54 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+$directory\
+$git_branch\
+$git_status\
+$python\
+$nodejs\
+$rust\
+$golang\
+$java\
+$docker_context\
+$line_break\
+$character"""
+
+[directory]
+truncation_length = 3
+truncation_symbol = ".../"
+
+[git_branch]
+format = "on [$branch]($style) "
+style = "bold purple"
+
+[git_status]
+format = '([$all_status$ahead_behind]($style) )'
+style = "bold red"
+
+[character]
+success_symbol = "[>](bold green)"
+error_symbol = "[>](bold red)"
+
+[python]
+format = '[py $version]($style) '
+style = "yellow"
+
+[nodejs]
+format = '[node $version]($style) '
+style = "green"
+
+[rust]
+format = '[rs $version]($style) '
+style = "red"
+
+[golang]
+format = '[go $version]($style) '
+style = "cyan"
+
+[java]
+format = '[java $version]($style) '
+style = "red"
+
+[docker_context]
+format = '[docker $context]($style) '
+style = "blue"


### PR DESCRIPTION
## Summary
- `.bashrc` に Starship プロンプトの初期化を追加
- `$HOME/.local/bin` を PATH に追加
- Starship の設定ファイルを追加（ディレクトリ省略表示、gitステータス、各言語バージョン表示）

## Test plan
- [x] `stow starship` で設定が正しくシンボリックリンクされること
- [ ] bashを起動してStarshipプロンプトが表示されること
- [x] ディレクトリ移動時に省略表示（`.../`）が正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)